### PR TITLE
Revert the changes causing performance regression

### DIFF
--- a/misc_scripts/controlleruse.sh
+++ b/misc_scripts/controlleruse.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+# Provide a script to create a cgroup
+mkdir temp;
+mkdir -p /sys/fs/cgroup/cpu/temp;
+# Will spawn a container now
+echo $$ > /sys/fs/cgroup/cpu/temp/cgroup.procs;
+$@
+rm -rf /sys/fs/cgroup/cpu/temp 

--- a/misc_scripts/controlleruse.sh
+++ b/misc_scripts/controlleruse.sh
@@ -1,9 +1,0 @@
-#! /bin/bash
-
-# Provide a script to create a cgroup
-mkdir temp;
-mkdir -p /sys/fs/cgroup/cpu/temp;
-# Will spawn a container now
-echo $$ > /sys/fs/cgroup/cpu/temp/cgroup.procs;
-$@
-rm -rf /sys/fs/cgroup/cpu/temp 

--- a/misc_scripts/exercise_map_anon.c
+++ b/misc_scripts/exercise_map_anon.c
@@ -1,0 +1,22 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/mman.h>
+
+int main(){
+
+    int ARRAYLEN=5;
+    int *ptr = mmap ( NULL, N*sizeof(int), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0 );
+    if(ptr == MAP_FAILED){
+        printf("Error\n");
+        return -1;
+    }
+
+    for(int i=0; i<ARRAYLEN; i++){
+        printf("[%d] ",ptr[i]);
+    }
+
+    int err = munmap(ptr, 10*sizeof(int));
+
+    return 0;
+}


### PR DESCRIPTION
use of cgroup controller in raw form may crash the system when the shell has PID = 1